### PR TITLE
[EL-3827] Allowing the tree grid to only select nodes in scope when the data is filtered

### DIFF
--- a/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
+++ b/src/ng1/directives/treegrid/treegridMultipleSelectItem.directive.js
@@ -98,7 +98,7 @@ export function treegridMultipleSelectItem() {
                             return false;
                         });
 
-                        scope.$on('destroy', () => {
+                        scope.$on('$destroy', () => {
                             element.off('click.multiSelect');
                             element.off('keydown.multiSelect');
                             element.off('treegrid-navigation-focused');


### PR DESCRIPTION
#### Checklist
<!-- Use an 'x' to check those which apply. -->
* [x] The contents of this PR are mine to submit. No third party code or other material is being committed.
* [x] New third party dependencies (if any) are linked via `package.json`. Third party dependencies are licenced under one of the following: Apache, MIT, BSD, Mozilla Public License, Eclipse Public License, or Oracle Binary Code License.
* [x] The code in this PR does not contain export-restricted encryption algorithms.

#### Ticket / Issue
<!-- Either a Jira URL or a description of the issue that this PR addresses. -->
* This addresses the issue reported on EL-3827. When a tree grid view data is filtered and a node with children is selected, all of its children will be selected (instead of just the filtered/visible ones)

#### Description of Proposed Changes
<!-- Describe what was changed and how it addresses the original issue. -->
The $scope event name in treegridMultipleSelectItem was changed from `destroy` to `$destroy`, so it gets executed when the filter is changed.

#### Documentation CI URL
<!-- Initiate a build at https://jenkins.swinfra.net/job/SEPG/view/Templates/job/New%20SEPG%20Build/build -->
<!-- Append the branch name to the following URL: -->
https://pages.github.houston.softwaregrp.net/sepg-docs-qa/UXAspects_CI_UXAspects-ng1_el-3827
